### PR TITLE
Drop support for pydantic v1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2409,4 +2409,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f27fbdef40e9aa349354e2f7f614990974b7bc2343cbbab2f81968b5b8d30f90"
+content-hash = "1f60e87036eb9cc41ca78f31fa90e1f90ad5711d7f72c5920f3fad3be2ee5616"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 python = "^3.11"
 aiohttp = ">=3.0.0"
 yarl = ">=1.6.0"
-pydantic = ">=1.10.8"
+pydantic = ">=2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 aresponses = "3.0.0"

--- a/src/youtubeaio/models.py
+++ b/src/youtubeaio/models.py
@@ -281,4 +281,4 @@ class YouTubePlaylistItem(BaseModel):
         return self.nullable_content_details
 
 
-YouTubeChannelSnippet.update_forward_refs()
+YouTubeChannelSnippet.model_rebuild()


### PR DESCRIPTION
# Proposed Changes

Pydantic will only support Python 3.14 for v2 models. https://github.com/pydantic/pydantic/issues/11613#issuecomment-3061291322
Technically it would be enough here to require `v2` for `>=3.14` via markers but I think at this point it's probably fine to drop support for `v1`.
